### PR TITLE
Translator Locale Resolvers

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -4,6 +4,7 @@ $finder = PhpCsFixer\Finder::create()
 	->in(__DIR__ . '/src')
 	->in(__DIR__ . '/tests')
 	->exclude('temp')
+	->name('*.phpt')
 ;
 
 return PhpCsFixer\Config::create()

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ final class FooService
 }
 ```
 
-### Translator Locale
+### Translator Localizer
 
 The Container contains an service of type `TranslatorLocalizerInterface` for manipulating with the Translator locale.
 
@@ -119,6 +119,58 @@ final class FooService
 
         # Set the new locale
         $this->localizer->setLocale('cs_CZ');
+    }
+}
+```
+
+### Translator Locale Resolver
+
+The Translator's locale can be resolved with own resolvers like this:
+
+```php
+<?php
+
+use Nette\Localization\ITranslator;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface;
+
+final class MyLocaleResolver implements TranslatorLocaleResolverInterface
+{
+    public function resolveLocale(ITranslator $translator) : ?string
+    {
+        # return a valid locale or NULL
+    }
+}
+```
+
+Resolvers can be registered manually with a tag `68publishers.translation_bridge.translator_locale_resolver` or through a `CompilerExtension` and each resolver can have priority.
+They are sorted by priority in descending order so a Resolver with the highest priority will be called first. A default priority is 0.
+
+Resolvers defined in `Kdyby` and `Contributte` integrations are automatically wrapped and provided into the main Resolver. Their priority is always 10.
+
+```neon
+    services: 
+        -
+            type: MyLocaleResolver
+            tags:
+                68publishers.translation_bridge.translator_locale_resolver: 15
+```
+
+Or
+
+```php
+<?php
+
+use Nette\DI\CompilerExtension;
+use SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolver;
+use SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolverProviderInterface;
+
+final class FooBundleExtension extends CompilerExtension implements TranslatorLocaleResolverProviderInterface
+{
+    public function getTranslatorLocaleResolvers(): array
+    {
+        return [
+            new TranslatorLocaleResolver(MyLocaleResolver::class, 15),
+        ];
     }
 }
 ```

--- a/src/Bridge/Contributte/DI/TranslationBridgeExtension.php
+++ b/src/Bridge/Contributte/DI/TranslationBridgeExtension.php
@@ -4,25 +4,50 @@ declare(strict_types=1);
 
 namespace SixtyEightPublishers\TranslationBridge\Bridge\Contributte\DI;
 
+use Nette\DI\Definitions\Statement;
 use Nette\Localization\ITranslator;
+use Contributte\Translation\DI\TranslationExtension;
 use Contributte\Translation\DI\TranslationProviderInterface;
+use SixtyEightPublishers\TranslationBridge\Exception\RuntimeException;
+use SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolver;
 use SixtyEightPublishers\TranslationBridge\DI\AbstractTranslationBridgeExtension;
 use SixtyEightPublishers\TranslationBridge\Bridge\Contributte\PrefixedTranslatorFactory;
+use SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolverProviderInterface;
+use SixtyEightPublishers\TranslationBridge\Bridge\Contributte\Localization\LocaleResolver;
 use SixtyEightPublishers\TranslationBridge\Bridge\SymfonyTranslation\Localization\TranslatorLocalizer;
+use SixtyEightPublishers\TranslationBridge\Bridge\Contributte\Localization\ContributteTranslatorLocaleResolver;
 
-final class TranslationBridgeExtension extends AbstractTranslationBridgeExtension implements TranslationProviderInterface
+final class TranslationBridgeExtension extends AbstractTranslationBridgeExtension implements TranslationProviderInterface, TranslatorLocaleResolverProviderInterface
 {
+	public const PRIORITY_CONTRIBUTTE_TRANSLATION_LOCALE_RESOLVER = 10;
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public function loadConfiguration(): void
 	{
+		if (empty($this->compiler->getExtensions(TranslationExtension::class))) {
+			throw new RuntimeException(sprintf(
+				'Please register extension %s.',
+				TranslationExtension::class
+			));
+		}
+
 		parent::loadConfiguration();
+
+		$builder = $this->getContainerBuilder();
 
 		$this->prefixedTranslatorFactoryDefinition->setFactory(PrefixedTranslatorFactory::class);
 		$this->translatorLocalizerDefinition->setFactory(TranslatorLocalizer::class, [
 			'@' . ITranslator::class,
 		]);
+
+		$builder->addDefinition($this->prefix('locale_resolver'))
+			->setType(LocaleResolver::class)
+			->setArguments([
+				sprintf('@%s.localeResolver', $this->getIntegratedExtensionName()),
+				$this->translatorLocaleResolverDefinition,
+			]);
 	}
 
 	/**
@@ -31,5 +56,43 @@ final class TranslationBridgeExtension extends AbstractTranslationBridgeExtensio
 	public function getTranslationResources(): array
 	{
 		return $this->collectTranslationResources();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getTranslatorLocaleResolvers(): array
+	{
+		return [
+			new TranslatorLocaleResolver(
+				new Statement(ContributteTranslatorLocaleResolver::class, [sprintf('@%s.localeResolver', $this->getIntegratedExtensionName())]),
+				self::PRIORITY_CONTRIBUTTE_TRANSLATION_LOCALE_RESOLVER
+			),
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function beforeCompileProcessTranslatorLocaleResolver(): void
+	{
+		parent::beforeCompileProcessTranslatorLocaleResolver();
+
+		$builder = $this->getContainerBuilder();
+
+		/** @var \Nette\DI\Definitions\ServiceDefinition $translator */
+		$translator = $builder->getDefinitionByType(ITranslator::class);
+
+		$translator->getFactory()->arguments['localeResolver'] = $builder->getDefinition($this->prefix('locale_resolver'));
+	}
+
+	/**
+	 * @return string|NULL
+	 */
+	private function getIntegratedExtensionName(): ?string
+	{
+		$extension = $this->compiler->getExtensions(TranslationExtension::class);
+
+		return key($extension);
 	}
 }

--- a/src/Bridge/Contributte/Localization/ContributteTranslatorLocaleResolver.php
+++ b/src/Bridge/Contributte/Localization/ContributteTranslatorLocaleResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Bridge\Contributte\Localization;
+
+use Nette\Localization\ITranslator;
+use Contributte\Translation\Translator as ContributteTranslator;
+use Contributte\Translation\LocaleResolver as ContributteLocaleResolver;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface;
+
+final class ContributteTranslatorLocaleResolver implements TranslatorLocaleResolverInterface
+{
+	/** @var \Contributte\Translation\LocaleResolver  */
+	private $resolver;
+
+	/**
+	 * @param \Contributte\Translation\LocaleResolver $resolver
+	 */
+	public function __construct(ContributteLocaleResolver $resolver)
+	{
+		$this->resolver = $resolver;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function resolveLocale(ITranslator $translator): ?string
+	{
+		return (function (ContributteTranslator $translator) {
+			return $this->resolver->resolve($translator);
+		})($translator);
+	}
+}

--- a/src/Bridge/Contributte/Localization/LocaleResolver.php
+++ b/src/Bridge/Contributte/Localization/LocaleResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Bridge\Contributte\Localization;
+
+use Contributte\Translation\Translator;
+use Contributte\Translation\LocalesResolvers\ResolverInterface;
+use Contributte\Translation\LocaleResolver as ContributteLocaleResolver;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface;
+
+final class LocaleResolver extends ContributteLocaleResolver
+{
+	/** @var \Contributte\Translation\LocaleResolver  */
+	private $inner;
+
+	/** @var \SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface  */
+	private $translatorLocaleResolver;
+
+	/**
+	 * @param \Contributte\Translation\LocaleResolver                                                $inner
+	 * @param \SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface $translatorLocaleResolver
+	 */
+	public function __construct(ContributteLocaleResolver $inner, TranslatorLocaleResolverInterface $translatorLocaleResolver)
+	{
+		$this->inner = $inner;
+		$this->translatorLocaleResolver = $translatorLocaleResolver;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getResolvers(): array
+	{
+		return $this->inner->getResolvers();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function addResolver(ResolverInterface $resolver): ContributteLocaleResolver
+	{
+		return $this->inner->addResolver($resolver);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function resolve(Translator $translator): string
+	{
+		return $this->translatorLocaleResolver->resolveLocale($translator);
+	}
+}

--- a/src/Bridge/Kdyby/DI/TranslationBridgeExtension.php
+++ b/src/Bridge/Kdyby/DI/TranslationBridgeExtension.php
@@ -4,25 +4,49 @@ declare(strict_types=1);
 
 namespace SixtyEightPublishers\TranslationBridge\Bridge\Kdyby\DI;
 
+use Kdyby\Translation\Translator;
 use Kdyby\Translation\ITranslator;
+use Nette\DI\Definitions\Statement;
+use Kdyby\Translation\IUserLocaleResolver;
 use Kdyby\Translation\DI\ITranslationProvider;
+use Kdyby\Translation\DI\TranslationExtension;
+use SixtyEightPublishers\TranslationBridge\Exception\RuntimeException;
+use SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolver;
 use SixtyEightPublishers\TranslationBridge\DI\AbstractTranslationBridgeExtension;
 use SixtyEightPublishers\TranslationBridge\Bridge\Kdyby\PrefixedTranslatorFactory;
+use SixtyEightPublishers\TranslationBridge\Bridge\Kdyby\Localization\UserLocaleResolver;
+use SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolverProviderInterface;
+use SixtyEightPublishers\TranslationBridge\Bridge\Kdyby\Localization\KdybyTranslatorLocaleResolver;
 use SixtyEightPublishers\TranslationBridge\Bridge\SymfonyTranslation\Localization\TranslatorLocalizer;
 
-final class TranslationBridgeExtension extends AbstractTranslationBridgeExtension implements ITranslationProvider
+final class TranslationBridgeExtension extends AbstractTranslationBridgeExtension implements ITranslationProvider, TranslatorLocaleResolverProviderInterface
 {
+	public const PRIORITY_KDYBY_TRANSLATION_LOCALE_RESOLVER = 10;
+
 	/**
 	 * {@inheritDoc}
 	 */
 	public function loadConfiguration(): void
 	{
+		if (empty($this->compiler->getExtensions(TranslationExtension::class))) {
+			throw new RuntimeException(sprintf(
+				'Please register extension %s.',
+				TranslationExtension::class
+			));
+		}
+
 		parent::loadConfiguration();
+
+		$builder = $this->getContainerBuilder();
 
 		$this->prefixedTranslatorFactoryDefinition->setFactory(PrefixedTranslatorFactory::class);
 		$this->translatorLocalizerDefinition->setFactory(TranslatorLocalizer::class, [
 			'@' . ITranslator::class,
 		]);
+
+		$builder->addDefinition($this->prefix('user_locale_resolver'))
+			->setType(IUserLocaleResolver::class)
+			->setFactory(UserLocaleResolver::class, [$this->translatorLocaleResolverDefinition]);
 	}
 
 	/**
@@ -31,5 +55,43 @@ final class TranslationBridgeExtension extends AbstractTranslationBridgeExtensio
 	public function getTranslationResources(): array
 	{
 		return $this->collectTranslationResources();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getTranslatorLocaleResolvers(): array
+	{
+		return [
+			new TranslatorLocaleResolver(
+				new Statement(KdybyTranslatorLocaleResolver::class, [sprintf('@%s.userLocaleResolver', $this->getIntegratedExtensionName())]),
+				self::PRIORITY_KDYBY_TRANSLATION_LOCALE_RESOLVER
+			),
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function beforeCompileProcessTranslatorLocaleResolver(): void
+	{
+		parent::beforeCompileProcessTranslatorLocaleResolver();
+
+		$builder = $this->getContainerBuilder();
+
+		/** @var \Nette\DI\Definitions\ServiceDefinition $translator */
+		$translator = $builder->getDefinitionByType(Translator::class);
+
+		$translator->getFactory()->arguments[0] = $builder->getDefinition($this->prefix('user_locale_resolver'));
+	}
+
+	/**
+	 * @return string|NULL
+	 */
+	private function getIntegratedExtensionName(): ?string
+	{
+		$extension = $this->compiler->getExtensions(TranslationExtension::class);
+
+		return key($extension);
 	}
 }

--- a/src/Bridge/Kdyby/Localization/KdybyTranslatorLocaleResolver.php
+++ b/src/Bridge/Kdyby/Localization/KdybyTranslatorLocaleResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Bridge\Kdyby\Localization;
+
+use Nette\Localization\ITranslator;
+use Kdyby\Translation\IUserLocaleResolver;
+use Kdyby\Translation\Translator as KdybyTranslator;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface;
+
+final class KdybyTranslatorLocaleResolver implements TranslatorLocaleResolverInterface
+{
+	/** @var \Kdyby\Translation\IUserLocaleResolver  */
+	private $userLocaleResolver;
+
+	/**
+	 * @param \Kdyby\Translation\IUserLocaleResolver $userLocaleResolver
+	 */
+	public function __construct(IUserLocaleResolver $userLocaleResolver)
+	{
+		$this->userLocaleResolver = $userLocaleResolver;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function resolveLocale(ITranslator $translator): ?string
+	{
+		return (function (KdybyTranslator $translator) {
+			return $this->userLocaleResolver->resolve($translator);
+		})($translator);
+	}
+}

--- a/src/Bridge/Kdyby/Localization/UserLocaleResolver.php
+++ b/src/Bridge/Kdyby/Localization/UserLocaleResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Bridge\Kdyby\Localization;
+
+use Kdyby\Translation\Translator;
+use Kdyby\Translation\IUserLocaleResolver;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface;
+
+final class UserLocaleResolver implements IUserLocaleResolver
+{
+	/** @var \SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface  */
+	private $translatorLocaleResolver;
+
+	/**
+	 * @param \SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface $translatorLocaleResolver
+	 */
+	public function __construct(TranslatorLocaleResolverInterface $translatorLocaleResolver)
+	{
+		$this->translatorLocaleResolver = $translatorLocaleResolver;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function resolve(Translator $translator): ?string
+	{
+		return $this->translatorLocaleResolver->resolveLocale($translator);
+	}
+}

--- a/src/DI/AbstractTranslationBridgeExtension.php
+++ b/src/DI/AbstractTranslationBridgeExtension.php
@@ -11,14 +11,21 @@ use Nette\DI\Definitions\FactoryDefinition;
 use SixtyEightPublishers\TranslationBridge\TranslatorAwareInterface;
 use SixtyEightPublishers\TranslationBridge\PrefixedTranslatorFactoryInterface;
 use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocalizerInterface;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverRegistry;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface;
 
 abstract class AbstractTranslationBridgeExtension extends CompilerExtension
 {
+	public const TAG_TRANSLATOR_LOCALE_RESOLVER = '68publishers.translation_bridge.translator_locale_resolver';
+
 	/** @var \Nette\DI\Definitions\ServiceDefinition|NULL */
 	protected $prefixedTranslatorFactoryDefinition;
 
 	/** @var \Nette\DI\Definitions\ServiceDefinition|NULL */
 	protected $translatorLocalizerDefinition;
+
+	/** @var \Nette\DI\Definitions\ServiceDefinition|NULL */
+	protected $translatorLocaleResolverDefinition;
 
 	/**
 	 * {@inheritDoc}
@@ -32,12 +39,41 @@ abstract class AbstractTranslationBridgeExtension extends CompilerExtension
 
 		$this->translatorLocalizerDefinition = $builder->addDefinition($this->prefix('translator_localizer'))
 			->setType(TranslatorLocalizerInterface::class);
+
+		$this->translatorLocaleResolverDefinition = $builder->addDefinition($this->prefix('translator_locale_resolver'))
+			->setType(TranslatorLocaleResolverInterface::class)
+			->setAutowired(FALSE);
+
+		$this->registerTranslatorLocaleResolvers();
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
 	public function beforeCompile(): void
+	{
+		$this->beforeCompileProcessTranslatorAware();
+		$this->beforeCompileProcessTranslatorLocaleResolver();
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function collectTranslationResources(): array
+	{
+		$resources = [];
+
+		foreach ($this->compiler->getExtensions(TranslationProviderInterface::class) as $extension) {
+			$resources[] = array_values($extension->getTranslationResources());
+		}
+
+		return array_merge([], ...$resources);
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function beforeCompileProcessTranslatorAware(): void
 	{
 		$builder = $this->getContainerBuilder();
 		$translator = $builder->getByType(ITranslator::class, FALSE);
@@ -63,16 +99,41 @@ abstract class AbstractTranslationBridgeExtension extends CompilerExtension
 	}
 
 	/**
-	 * @return array
+	 * @return void
 	 */
-	protected function collectTranslationResources(): array
+	protected function beforeCompileProcessTranslatorLocaleResolver(): void
 	{
-		$resources = [];
+		$builder = $this->getContainerBuilder();
+		$services = $builder->findByTag(self::TAG_TRANSLATOR_LOCALE_RESOLVER);
 
-		foreach ($this->compiler->getExtensions(TranslationProviderInterface::class) as $extension) {
-			$resources[] = array_values($extension->getTranslationResources());
+		uasort($services, static function ($a, $b) {
+			return (is_int($b) ? $b : 0) <=> (is_int($a) ? $a : 0);
+		});
+
+		$this->translatorLocaleResolverDefinition->setFactory(TranslatorLocaleResolverRegistry::class, [
+			array_map(static function (string $serviceName) use ($builder) {
+				return $builder->getDefinition($serviceName);
+			}, array_keys($services)),
+		]);
+	}
+
+	/**
+	 * @return void
+	 */
+	private function registerTranslatorLocaleResolvers(): void
+	{
+		$builder = $this->getContainerBuilder();
+		$i = 0;
+
+		/** @var \SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolverProviderInterface $extension */
+		foreach ($this->compiler->getExtensions(TranslatorLocaleResolverProviderInterface::class) as $extension) {
+			foreach ($extension->getTranslatorLocaleResolvers() as $translatorLocaleResolver) {
+				$builder->addDefinition($this->prefix('translation_locale_resolver.extension.' . $i++))
+					->setType(TranslatorLocaleResolverInterface::class)
+					->setFactory($translatorLocaleResolver->factory)
+					->setAutowired(FALSE)
+					->addTag(self::TAG_TRANSLATOR_LOCALE_RESOLVER, $translatorLocaleResolver->priority);
+			}
 		}
-
-		return array_merge([], ...$resources);
 	}
 }

--- a/src/DI/TranslatorLocaleResolver.php
+++ b/src/DI/TranslatorLocaleResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\DI;
+
+final class TranslatorLocaleResolver
+{
+	/** @var mixed  */
+	public $factory;
+
+	/** @var int  */
+	public $priority;
+
+	/**
+	 * @param mixed $factory
+	 * @param int   $priority
+	 */
+	public function __construct($factory, int $priority = 0)
+	{
+		$this->factory = $factory;
+		$this->priority = $priority;
+	}
+}

--- a/src/DI/TranslatorLocaleResolverProviderInterface.php
+++ b/src/DI/TranslatorLocaleResolverProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\DI;
+
+interface TranslatorLocaleResolverProviderInterface
+{
+	/**
+	 * @return \SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolver[]
+	 */
+	public function getTranslatorLocaleResolvers(): array;
+}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Exception;
+
+final class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Localization/TranslatorLocaleResolverInterface.php
+++ b/src/Localization/TranslatorLocaleResolverInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Localization;
+
+use Nette\Localization\ITranslator;
+
+interface TranslatorLocaleResolverInterface
+{
+	/**
+	 * @param \Nette\Localization\ITranslator $translator
+	 *
+	 * @return string|NULL
+	 */
+	public function resolveLocale(ITranslator $translator): ?string;
+}

--- a/src/Localization/TranslatorLocaleResolverRegistry.php
+++ b/src/Localization/TranslatorLocaleResolverRegistry.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Localization;
+
+use Nette\Localization\ITranslator;
+
+final class TranslatorLocaleResolverRegistry implements TranslatorLocaleResolverInterface
+{
+	/** @var \SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface[] */
+	private $resolvers;
+
+	/**
+	 * @param \SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface[] $resolvers
+	 */
+	public function __construct(array $resolvers)
+	{
+		$this->resolvers = (static function (TranslatorLocaleResolverInterface ...$resolvers): array {
+			return $resolvers;
+		})(...$resolvers);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function resolveLocale(ITranslator $translator): ?string
+	{
+		foreach ($this->resolvers as $resolver) {
+			if (NULL !== ($locale = $resolver->resolveLocale($translator))) {
+				return $locale;
+			}
+		}
+
+		return NULL;
+	}
+}

--- a/tests/Cases/Bridge/SymfonyTranslation/Localization/TranslatorLocalizerTestCase.phpt
+++ b/tests/Cases/Bridge/SymfonyTranslation/Localization/TranslatorLocalizerTestCase.phpt
@@ -29,7 +29,7 @@ class TranslatorLocalizerTestCase extends TestCase
 	/**
 	 * @return void
 	 */
-	public function testLocaleIsReturned() : void
+	public function testLocaleIsReturned(): void
 	{
 		$localeAware = Mockery::mock(Translator::class);
 		$localizer = new TranslatorLocalizer($localeAware);
@@ -44,7 +44,7 @@ class TranslatorLocalizerTestCase extends TestCase
 	/**
 	 * @return void
 	 */
-	public function testSetLocale() : void
+	public function testSetLocale(): void
 	{
 		$localeAware = Mockery::mock(Translator::class);
 		$localizer = new TranslatorLocalizer($localeAware);

--- a/tests/Cases/Localization/TranslatorLocaleResolverRegistryTestCase.phpt
+++ b/tests/Cases/Localization/TranslatorLocaleResolverRegistryTestCase.phpt
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Tests\Cases\Localization;
+
+use Mockery;
+use Tester\Assert;
+use Tester\TestCase;
+use Nette\Localization\ITranslator;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverRegistry;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface;
+
+require __DIR__ . '/../../bootstrap.php';
+
+class TranslatorLocaleResolverRegistryTestCase extends TestCase
+{
+	/** @var \Nette\Localization\ITranslator */
+	private $translator;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->translator = Mockery::mock(ITranslator::class);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+
+		Mockery::close();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRegistryShouldReturnNullWhenIsEmptyOrLocaleIsNotResolved(): void
+	{
+		$emptyRegistry = new TranslatorLocaleResolverRegistry([]);
+
+		Assert::null($emptyRegistry->resolveLocale($this->translator));
+
+		$nonEmptyRegistry = new TranslatorLocaleResolverRegistry([
+			$resolver = Mockery::mock(TranslatorLocaleResolverInterface::class),
+		]);
+
+		$resolver->shouldReceive('resolveLocale')->andReturnNull();
+
+		Assert::null($nonEmptyRegistry->resolveLocale($this->translator));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRegistryShouldReturnLocaleWheyLocaleIsResolved(): void
+	{
+		$nullResolver = Mockery::mock(TranslatorLocaleResolverInterface::class);
+		$enUsResolver = Mockery::mock(TranslatorLocaleResolverInterface::class);
+		$csCzResolver= Mockery::mock(TranslatorLocaleResolverInterface::class);
+
+		$nullResolver->shouldReceive('resolveLocale')->andReturnNull();
+		$enUsResolver->shouldReceive('resolveLocale')->andReturn('en_US');
+		$csCzResolver->shouldReceive('resolveLocale')->andReturn('cs_CZ');
+
+		$firstRegistry = new TranslatorLocaleResolverRegistry([$enUsResolver, $csCzResolver]);
+
+		$secondRegistry = new TranslatorLocaleResolverRegistry([$nullResolver, $csCzResolver]);
+
+		Assert::same('en_US', $firstRegistry->resolveLocale($this->translator));
+		Assert::same('cs_CZ', $secondRegistry->resolveLocale($this->translator));
+	}
+}
+
+(new TranslatorLocaleResolverRegistryTestCase())->run();

--- a/tests/Fixtures/SimpleTranslatorLocaleResolver.php
+++ b/tests/Fixtures/SimpleTranslatorLocaleResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Tests\Fixtures;
+
+use Nette\Localization\ITranslator;
+use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface;
+
+final class SimpleTranslatorLocaleResolver implements TranslatorLocaleResolverInterface
+{
+	/** @var string  */
+	private $locale;
+
+	/**
+	 * @param string $locale
+	 */
+	public function __construct(string $locale)
+	{
+		$this->locale = $locale;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function resolveLocale(ITranslator $translator): ?string
+	{
+		return $this->locale;
+	}
+}

--- a/tests/Fixtures/TranslationProviderExtension.php
+++ b/tests/Fixtures/TranslationProviderExtension.php
@@ -7,7 +7,7 @@ namespace SixtyEightPublishers\TranslationBridge\Tests\Fixtures;
 use Nette\DI\CompilerExtension;
 use SixtyEightPublishers\TranslationBridge\DI\TranslationProviderInterface;
 
-final class TestProviderExtension extends CompilerExtension implements TranslationProviderInterface
+final class TranslationProviderExtension extends CompilerExtension implements TranslationProviderInterface
 {
 	/**
 	 * {@inheritDoc}

--- a/tests/Fixtures/TranslatorLocaleResolverProviderExtension.php
+++ b/tests/Fixtures/TranslatorLocaleResolverProviderExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SixtyEightPublishers\TranslationBridge\Tests\Fixtures;
+
+use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\Statement;
+use SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolver;
+use SixtyEightPublishers\TranslationBridge\DI\TranslatorLocaleResolverProviderInterface;
+
+final class TranslatorLocaleResolverProviderExtension extends CompilerExtension implements TranslatorLocaleResolverProviderInterface
+{
+	/** @var string  */
+	private $locale;
+
+	/**
+	 * @param string $locale
+	 */
+	public function __construct(string $locale)
+	{
+		$this->locale = $locale;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getTranslatorLocaleResolvers(): array
+	{
+		return [
+			new TranslatorLocaleResolver(new Statement(SimpleTranslatorLocaleResolver::class, [$this->locale]), 15),
+		];
+	}
+}

--- a/tests/bootstrap.contributte.php
+++ b/tests/bootstrap.contributte.php
@@ -7,4 +7,4 @@ if (@!include __DIR__ . '/../vendor-bin/contributte/vendor/autoload.php') {
 	exit(1);
 }
 
-require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/setup.php';

--- a/tests/bootstrap.kdyby.php
+++ b/tests/bootstrap.kdyby.php
@@ -7,4 +7,4 @@ if (@!include __DIR__ . '/../vendor-bin/kdyby/vendor/autoload.php') {
 	exit(1);
 }
 
-require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/setup.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,12 +2,9 @@
 
 declare(strict_types=1);
 
-Tester\Environment::setup();
-
-if (!defined('TEMP_PATH')) {
-	define('TEMP_PATH', __DIR__ . '/temp');
+if (@!include __DIR__ . '/../vendor/autoload.php') {
+	echo 'Please run `composer install && composer bin all install`';
+	exit(1);
 }
 
-if (!defined('CONFIG_DIR')) {
-	define('CONFIG_DIR', __DIR__ . '/config');
-}
+require __DIR__ . '/setup.php';

--- a/tests/bootstrap.symfony-translation.php
+++ b/tests/bootstrap.symfony-translation.php
@@ -7,4 +7,4 @@ if (@!include __DIR__ . '/../vendor-bin/kdyby/vendor/autoload.php') {
 	exit(1);
 }
 
-require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/setup.php';

--- a/tests/config/localization.neon
+++ b/tests/config/localization.neon
@@ -1,0 +1,5 @@
+parameters:
+	locale: fr_FR
+
+extensions:
+	test_translator_locale_resolver_provider: SixtyEightPublishers\TranslationBridge\Tests\Fixtures\TranslatorLocaleResolverProviderExtension(%locale%)

--- a/tests/config/translations.neon
+++ b/tests/config/translations.neon
@@ -1,0 +1,2 @@
+extensions:
+	test_translation_provider: SixtyEightPublishers\TranslationBridge\Tests\Fixtures\TranslationProviderExtension

--- a/tests/config/translator-aware.neon
+++ b/tests/config/translator-aware.neon
@@ -1,6 +1,3 @@
-extensions:
-	test_provider: SixtyEightPublishers\TranslationBridge\Tests\Fixtures\TestProviderExtension
-
 services:
 	- SixtyEightPublishers\TranslationBridge\Tests\Fixtures\TranslatableService
 	-

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+Tester\Environment::setup();
+
+if (!defined('TEMP_PATH')) {
+	define('TEMP_PATH', __DIR__ . '/temp');
+}
+
+if (!defined('CONFIG_DIR')) {
+	define('CONFIG_DIR', __DIR__ . '/config');
+}


### PR DESCRIPTION
- added interface `TranslatorLocaleResolverInterface` and implementor `TranslatorLocaleResolverRegistry`
- added exception `RuntimeException`
- added CompilerExtension interface `TranslatorLocaleResolverProviderInterface` and class `TranslatorLocaleResolver`
- added support for translator locale provider into both Bridges
- added test case `TranslatorLocaleResolverRegistryTestCase`
- main test cases (DI integration) were divided into more test methods and new tests have been added
- updated README