### PR TITLE
Fix [Contributte Bridge]: LocaleResolver warning

### DIFF
--- a/src/Bridge/Contributte/DI/TranslationBridgeExtension.php
+++ b/src/Bridge/Contributte/DI/TranslationBridgeExtension.php
@@ -45,7 +45,6 @@ final class TranslationBridgeExtension extends AbstractTranslationBridgeExtensio
 		$builder->addDefinition($this->prefix('locale_resolver'))
 			->setType(LocaleResolver::class)
 			->setArguments([
-				sprintf('@%s.localeResolver', $this->getIntegratedExtensionName()),
 				$this->translatorLocaleResolverDefinition,
 			]);
 	}

--- a/src/Bridge/Contributte/Localization/LocaleResolver.php
+++ b/src/Bridge/Contributte/Localization/LocaleResolver.php
@@ -5,42 +5,20 @@ declare(strict_types=1);
 namespace SixtyEightPublishers\TranslationBridge\Bridge\Contributte\Localization;
 
 use Contributte\Translation\Translator;
-use Contributte\Translation\LocalesResolvers\ResolverInterface;
 use Contributte\Translation\LocaleResolver as ContributteLocaleResolver;
 use SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface;
 
 final class LocaleResolver extends ContributteLocaleResolver
 {
-	/** @var \Contributte\Translation\LocaleResolver  */
-	private $inner;
-
 	/** @var \SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface  */
 	private $translatorLocaleResolver;
 
 	/**
-	 * @param \Contributte\Translation\LocaleResolver                                                $inner
 	 * @param \SixtyEightPublishers\TranslationBridge\Localization\TranslatorLocaleResolverInterface $translatorLocaleResolver
 	 */
-	public function __construct(ContributteLocaleResolver $inner, TranslatorLocaleResolverInterface $translatorLocaleResolver)
+	public function __construct(TranslatorLocaleResolverInterface $translatorLocaleResolver)
 	{
-		$this->inner = $inner;
 		$this->translatorLocaleResolver = $translatorLocaleResolver;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function getResolvers(): array
-	{
-		return $this->inner->getResolvers();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function addResolver(ResolverInterface $resolver): ContributteLocaleResolver
-	{
-		return $this->inner->addResolver($resolver);
 	}
 
 	/**


### PR DESCRIPTION
Fix: Changed implementation of `LocaleResolver` class in Contributte Bridge (method `::addResolver()` can not be overloaded because a return type is declared as `self`, this causes warning).
