### PR TITLE
Fallback locales access and nette/utils 3.2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
           - travis_retry composer install --no-progress --prefer-dist
           - travis_retry composer bin all install --no-progress --prefer-dist
         script:
-          - vendor/bin/tester -p phpdbg tests -s --coverage ./coverage.xml --coverage-src ./src -d zend_extension=xdebug.so
+          - vendor/bin/tester -p phpdbg tests -s --coverage ./coverage.xml --coverage-src ./src
         after_script:
           - wget https://scrutinizer-ci.com/ocular.phar
           - php ocular.phar code-coverage:upload --format=php-clover coverage.xml

--- a/src/Bridge/SymfonyTranslation/Localization/TranslatorLocalizer.php
+++ b/src/Bridge/SymfonyTranslation/Localization/TranslatorLocalizer.php
@@ -41,4 +41,12 @@ final class TranslatorLocalizer implements TranslatorLocalizerInterface
 	{
 		return $this->translator->getLocale();
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getFallbackLocales(): array
+	{
+		return $this->translator->getFallbackLocales();
+	}
 }

--- a/src/Localization/TranslatorLocalizerInterface.php
+++ b/src/Localization/TranslatorLocalizerInterface.php
@@ -18,4 +18,9 @@ interface TranslatorLocalizerInterface
 	 * @return string
 	 */
 	public function getLocale(): string;
+
+	/**
+	 * @return string[]
+	 */
+	public function getFallbackLocales(): array;
 }

--- a/tests/Cases/Bridge/AbstractTranslationBridgeExtensionTestCase.php
+++ b/tests/Cases/Bridge/AbstractTranslationBridgeExtensionTestCase.php
@@ -23,7 +23,7 @@ abstract class AbstractTranslationBridgeExtensionTestCase extends TestCase
 	public function testTranslations(): void
 	{
 		$container = $this->createContainer(CONFIG_DIR . '/translations.neon');
-		$translator = $container->getByType(ITranslator::class);
+		$translator = $this->getTranslatorService($container);
 
 		Assert::same('bar', $translator->translate('test_provider.foo'));
 
@@ -74,6 +74,13 @@ abstract class AbstractTranslationBridgeExtensionTestCase extends TestCase
 	 * @param \Nette\Configurator $configurator
 	 */
 	abstract protected function setupContainer(Configurator $configurator): void;
+
+	/**
+	 * @param \Nette\DI\Container $container
+	 *
+	 * @return \Nette\Localization\ITranslator
+	 */
+	abstract protected function getTranslatorService(Container $container): ITranslator;
 
 	/**
 	 * @param string|NULL $config

--- a/tests/Cases/Bridge/Contributte/DI/TranslationBridgeExtensionTestCase.phpt
+++ b/tests/Cases/Bridge/Contributte/DI/TranslationBridgeExtensionTestCase.phpt
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SixtyEightPublishers\TranslationBridge\Tests\Cases\Bridge\Contributte\DI;
 
 use Nette\Configurator;
+use Nette\DI\Container;
+use Nette\Localization\ITranslator;
 use SixtyEightPublishers\TranslationBridge\Tests\Cases\Bridge\AbstractTranslationBridgeExtensionTestCase;
 
 require __DIR__ . '/../../../../bootstrap.contributte.php';
@@ -17,6 +19,14 @@ class TranslationBridgeExtensionTestCase extends AbstractTranslationBridgeExtens
 	protected function setupContainer(Configurator $configurator): void
 	{
 		$configurator->addConfig(CONFIG_DIR . '/contributte.config.neon');
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function getTranslatorService(Container $container): ITranslator
+	{
+		return $container->getService('translation.translator');
 	}
 }
 

--- a/tests/Cases/Bridge/Kdyby/DI/TranslationBridgeExtensionTestCase.phpt
+++ b/tests/Cases/Bridge/Kdyby/DI/TranslationBridgeExtensionTestCase.phpt
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace SixtyEightPublishers\TranslationBridge\Tests\Cases\Bridge\Kdyby\DI;
 
 use Nette\Configurator;
+use Nette\DI\Container;
+use Nette\Localization\ITranslator;
+use Kdyby\Translation\ITranslator as KdybyTranslator;
 use SixtyEightPublishers\TranslationBridge\Tests\Cases\Bridge\AbstractTranslationBridgeExtensionTestCase;
 
 require __DIR__ . '/../../../../bootstrap.kdyby.php';
@@ -17,6 +20,14 @@ class TranslationBridgeExtensionTestCase extends AbstractTranslationBridgeExtens
 	protected function setupContainer(Configurator $configurator): void
 	{
 		$configurator->addConfig(CONFIG_DIR . '/kdyby.config.neon');
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function getTranslatorService(Container $container): ITranslator
+	{
+		return $container->getByType(KdybyTranslator::class);
 	}
 }
 

--- a/tests/setup.php
+++ b/tests/setup.php
@@ -11,3 +11,5 @@ if (!defined('TEMP_PATH')) {
 if (!defined('CONFIG_DIR')) {
 	define('CONFIG_DIR', __DIR__ . '/config');
 }
+
+error_reporting(~E_USER_DEPRECATED);


### PR DESCRIPTION
- added method `TranslatorLocalizerInterface::getFallbackLocales()`
- added new assert into the test `TranslatorLocalizerTestCase` and real Translator is used insted of mock
- added abstract method `AbstractTranslationBridgeExtensionTestCase::getTranslatorService()` - the translator is accessible with an interface name `ITranslator` but the name is internally translated to `Translator` from `nette/utils^3.2`